### PR TITLE
Prevent cv content being fetched every time CVModal component is mounted

### DIFF
--- a/src/components/CVModal/container.js
+++ b/src/components/CVModal/container.js
@@ -13,14 +13,12 @@ const CVModalContainer = Wrapped =>
 
     state = { cvURL: null, isModalOpen: false };
 
-    componentDidMount() {
-      fetchCV().then(data => this.setState({ isModalOpen: false, cvURL: data }));
-    }
-
     componentDidUpdate(prevProps) {
       const { selectedValues } = this.props;
+
       if (prevProps.selectedValues !== selectedValues) {
         this.setState({ selectedValues, isModalOpen: true });
+        fetchCV().then(data => this.setState({ isModalOpen: true, cvURL: data }));
       }
     }
 
@@ -29,18 +27,14 @@ const CVModalContainer = Wrapped =>
     render() {
       const { selectedValues, isModalOpen, cvURL } = this.state;
 
-      if (selectedValues && selectedValues.length > 0) {
-        return (
-          <Wrapped
-            selectedValues={selectedValues}
-            handleCancelClick={this.handleCancelModal}
-            isModalOpen={isModalOpen}
-            cvURL={cvURL}
-          />
-        );
-      }
-
-      return null;
+      return (
+        <Wrapped
+          selectedValues={selectedValues}
+          handleCancelClick={this.handleCancelModal}
+          isModalOpen={isModalOpen}
+          cvURL={cvURL}
+        />
+      );
     }
   };
 


### PR DESCRIPTION
Resolves [CG-50](https://unosquarebelfast.atlassian.net/browse/CG-50)

Dependency
- [x] https://github.com/UnosquareBelfast/CVGenerator-frontend/pull/26

This bug fix prevents the fetchPDF api being called everytime the CVModal component is mounted. Instead now the api is called when the component receives selectedValues from the dropdowns as props.